### PR TITLE
Inview not working on page refresh in Firefox (no .onscreen class gets added)

### DIFF
--- a/gumby.inview.js
+++ b/gumby.inview.js
@@ -178,7 +178,11 @@
 		$(window).trigger('scroll');
 	});
 
-
+	//on page refresh - trigger scroll
+	$(window).load(function () {
+		$(window).trigger('scroll');
+	});
+	
 	// add toggle Initialization
 	Gumby.addInitalisation('inview', function(all) {
 		


### PR DESCRIPTION
Inview is not working for me on pagerefresh in FF 28.0
The .onscreen class gets added only after scrolling or resizing the window.
Problem is solved with an added $(window).load() function triggering the scroll event.
