### PR TITLE
FIX gumby.inview.js to allow empty data-target attribute

### DIFF
--- a/gumby.inview.js
+++ b/gumby.inview.js
@@ -80,8 +80,8 @@
 	InViewWatcher.prototype.parseTargets = function() {
 		var targetStr = Gumby.selectAttr.apply(this.$el, ['target']);
 
-		// no targets so return false
-		if(!targetStr) {
+		// no targets so return false (if attr set but no value, targetStr will be true (also check for length)
+		if(!targetStr.length) {
 			return false;
 		}
 


### PR DESCRIPTION
If data-target attribute is set but has no value, targetStr will be true and a js error will occur. Fix: check for length of the attribute value (it will be boolean true if there's no value, length of boolean == undefined (so false)).
